### PR TITLE
fix:removed mandatory field in footer callout

### DIFF
--- a/fieldkit/acf-json/group_5f084ed589261.json
+++ b/fieldkit/acf-json/group_5f084ed589261.json
@@ -359,7 +359,7 @@
                     "name": "heading",
                     "type": "text",
                     "instructions": "",
-                    "required": 1,
+                    "required": 0,
                     "conditional_logic": 0,
                     "wrapper": {
                         "width": "",
@@ -426,5 +426,5 @@
     "hide_on_screen": "",
     "active": true,
     "description": "",
-    "modified": 1618383866
+    "modified": 1622164257
 }


### PR DESCRIPTION
@jhow04 we already removed the mandatory field in footer callout for the product page.
here's the ticket link: https://code.conservify.org/jira/browse/FK-3747
thanks.