### PR TITLE
chore: version bump templates - 02/2024

### DIFF
--- a/fieldkit/woocommerce/cart/cart-shipping.php
+++ b/fieldkit/woocommerce/cart/cart-shipping.php
@@ -14,7 +14,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 7.3.0
+ * @version 8.6.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/fieldkit/woocommerce/checkout/form-pay.php
+++ b/fieldkit/woocommerce/checkout/form-pay.php
@@ -12,7 +12,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 7.8.0
+ * @version 8.2.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/fieldkit/woocommerce/checkout/payment.php
+++ b/fieldkit/woocommerce/checkout/payment.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 7.8.0
+ * @version 8.1.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/fieldkit/woocommerce/checkout/thankyou.php
+++ b/fieldkit/woocommerce/checkout/thankyou.php
@@ -12,7 +12,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates
- * @version 3.7.0
+ * @version 8.1.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/fieldkit/woocommerce/myaccount/orders.php
+++ b/fieldkit/woocommerce/myaccount/orders.php
@@ -14,7 +14,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 7.8.0
+ * @version 8.5.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/fieldkit/woocommerce/order/order-details.php
+++ b/fieldkit/woocommerce/order/order-details.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 7.8.0
+ * @version 8.5.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/fieldkit/woocommerce/single-product/composite-add-to-cart.php
+++ b/fieldkit/woocommerce/single-product/composite-add-to-cart.php
@@ -9,7 +9,7 @@
  * When this occurs the version of the template file will be bumped and the readme will list any important changes.
  *
  * @since    1.0.0
- * @version  8.8.0
+ * @version  8.10.4
  */
 
 // Exit if accessed directly.


### PR DESCRIPTION
No major fixes were applied to our template Overrides.
 
[Woocommerce 8.6.0](https://github.com/woocommerce/woocommerce/blob/trunk/changelog.txt)
